### PR TITLE
Add undo and resume functionality

### DIFF
--- a/bin-resources/meta.json
+++ b/bin-resources/meta.json
@@ -43,6 +43,6 @@
 		"vsLabelsOnSplitsPage": false,
 		"teamGameIcons": false,
 		"mainLayoutBackground": true,
-		"enableRemoteSplitting": true
+		"enableRemoteSplitting": false
 	}
 }

--- a/ffrelaytoolv1/MainForm.Designer.cs
+++ b/ffrelaytoolv1/MainForm.Designer.cs
@@ -57,6 +57,7 @@
             this.MogSplitVs2 = new System.Windows.Forms.Label();
             this.MogSplitName6 = new System.Windows.Forms.Label();
             this.MogSplitName7 = new System.Windows.Forms.Label();
+            this.ResumeButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // MainTimer
@@ -410,12 +411,23 @@
             this.MogSplitName7.Text = "Team Tonberry:";
             this.MogSplitName7.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
+            // ResumeButton
+            // 
+            this.ResumeButton.Location = new System.Drawing.Point(620, 22);
+            this.ResumeButton.Name = "ResumeButton";
+            this.ResumeButton.Size = new System.Drawing.Size(60, 90);
+            this.ResumeButton.TabIndex = 21;
+            this.ResumeButton.Text = "Resume Timer";
+            this.ResumeButton.UseVisualStyleBackColor = true;
+            this.ResumeButton.Click += new System.EventHandler(this.button1_Click_2);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(614, 131);
+            this.ClientSize = new System.Drawing.Size(726, 131);
+            this.Controls.Add(this.ResumeButton);
             this.Controls.Add(this.CommUpdate);
             this.Controls.Add(this.stopbutton);
             this.Controls.Add(this.startbutton);
@@ -460,6 +472,7 @@
         private System.Windows.Forms.Label MogSplitVs2;
         private System.Windows.Forms.Label MogSplitName6;
         private System.Windows.Forms.Label MogSplitName7;
+        private System.Windows.Forms.Button ResumeButton;
     }
 }
 

--- a/ffrelaytoolv1/TeamControl.Designer.cs
+++ b/ffrelaytoolv1/TeamControl.Designer.cs
@@ -32,6 +32,7 @@
             this.TimerLabel = new System.Windows.Forms.Label();
             this.teamTabGroup = new System.Windows.Forms.TabControl();
             this.cycleIconButton = new System.Windows.Forms.Button();
+            this.undoButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // TeamSplitButton
@@ -39,7 +40,7 @@
             this.TeamSplitButton.BackColor = System.Drawing.Color.CornflowerBlue;
             this.TeamSplitButton.Location = new System.Drawing.Point(384, 8);
             this.TeamSplitButton.Name = "TeamSplitButton";
-            this.TeamSplitButton.Size = new System.Drawing.Size(400, 64);
+            this.TeamSplitButton.Size = new System.Drawing.Size(357, 64);
             this.TeamSplitButton.TabIndex = 17;
             this.TeamSplitButton.Text = "Team Mog Split";
             this.TeamSplitButton.UseVisualStyleBackColor = false;
@@ -75,10 +76,21 @@
             this.cycleIconButton.UseVisualStyleBackColor = true;
             this.cycleIconButton.Click += new System.EventHandler(this.button1_Click);
             // 
+            // undoButton
+            // 
+            this.undoButton.Location = new System.Drawing.Point(758, 8);
+            this.undoButton.Name = "undoButton";
+            this.undoButton.Size = new System.Drawing.Size(59, 63);
+            this.undoButton.TabIndex = 20;
+            this.undoButton.Text = "Undo";
+            this.undoButton.UseVisualStyleBackColor = true;
+            this.undoButton.Click += new System.EventHandler(this.undoButton_Click);
+            // 
             // TeamControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.undoButton);
             this.Controls.Add(this.cycleIconButton);
             this.Controls.Add(this.TimerLabel);
             this.Controls.Add(this.TeamSplitButton);
@@ -95,7 +107,6 @@
         private System.Windows.Forms.Label TimerLabel;
         private System.Windows.Forms.TabControl teamTabGroup;
         private System.Windows.Forms.Button cycleIconButton;
-
-
+        private System.Windows.Forms.Button undoButton;
     }
 }

--- a/ffrelaytoolv1/TeamInfo.cs
+++ b/ffrelaytoolv1/TeamInfo.cs
@@ -35,8 +35,6 @@ namespace ffrelaytoolv1
 
         public int teamTab { get; set; }
 
-        public string[] teamGameEndArchive { get; set; }
-
         public Color color { get; set; }
 
         public Image tabBackground { get; set; }
@@ -68,16 +66,14 @@ namespace ffrelaytoolv1
                 throw new Exception("Unable to find file with name "+runnerFileName);
             }
             teamGameEnd = new string[numberOfGames];
-            teamGameEndArchive = new string[numberOfGames];
             for (int i = 0; i < numberOfGames; i++)
             {
-                teamGameEnd[i] = "00:00:00";
-                teamGameEndArchive[i] = "00:00:00";
+                teamGameEnd[i] = Util.emptyTime;
             }
             teamSplits = new string[numberOfSplits];
             for (int i = 0; i < numberOfSplits; i++)
             {
-                teamSplits[i] = "00:00:00";
+                teamSplits[i] = Util.emptyTime;
             }
             this.useIcons = useIcons;
             cycleTeamIcon(() => { });

--- a/ffrelaytoolv1/Util.cs
+++ b/ffrelaytoolv1/Util.cs
@@ -109,5 +109,15 @@ namespace ffrelaytoolv1
                 ", r: " + (parent.ClientSize.Width - outer.Sum(c => c.Location.X) - control.Location.X - control.Size.Width) +
                 ", b: " + (parent.ClientSize.Height - outer.Sum(c => c.Location.Y) - control.Location.Y - control.Size.Height);
         }
+
+        public static int getGameIndexForSplit(string[] splits, int index)
+        {
+            return splits.Take(index).Aggregate(0, (game, split) => split.StartsWith(gameSep) ? game+1 : game);
+        }
+
+        public static (string,int)[] extractGameEndsFromSplits(string[] splits)
+        {
+            return splits.Select((split, index) => (split, index)).Where(pair => pair.split.StartsWith(gameSep)).ToArray();
+        }
     }
 }


### PR DESCRIPTION
Improves resilience of tool under restart/crashes
Allows for splits to be undone
Game index and differences will correctly catch up if splits are reloaded from file
Resumption time can be adjusted in split output along with split times